### PR TITLE
:ambulance:  Wrong version number

### DIFF
--- a/packages/molecules/step-list/package.json
+++ b/packages/molecules/step-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dusk-network/step-list",
-  "version": "4.6.3",
+  "version": "4.6.5",
   "description": "Dusk UI Kit - StepList",
   "bugs": {
     "url": "https://github.com/dusk-network/dusk-ui-kit/issues"


### PR DESCRIPTION
Fixed version number 4.6.3 -> 4.6.5 for step-list package